### PR TITLE
Replaced naming filename for FileSystemStorage

### DIFF
--- a/fastapi_storages/filesystem.py
+++ b/fastapi_storages/filesystem.py
@@ -51,8 +51,8 @@ class FileSystemStorage(BaseStorage):
         Write input file which is opened in binary mode to destination.
         """
 
-        filename = secure_filename(name)
-        path = self._path / Path(filename)
+        filename = self.get_name(name)
+        path = self.get_path(filename)
 
         file.seek(0, 0)
         with open(path, "wb") as output:


### PR DESCRIPTION
Hi,

The write method of FileSystemStorage creates the path directly, which I think is the same behavior as the get_name and get_path methods. How about using the get_name and get_path methods? This is because this way we can override these two methods to have more control over the file storage path.

Here's an example.

```python
class FileSystemStorage(BaseFileSystemStorage):
    _path_factory: Optional[Callable] = None

    def __init__(self, path: Optional[Path | str] = None, path_factory: Optional[Callable] = None) -> None:
        self._path_factory = path_factory
        super().__init__(path)

    def get_path(self, name: str) -> str:
        if callable(self._path_factory):
            _path = self._path_factory()
        else:
            _path = self._path

        return str(Path(_path) / Path(name))
```