### PR TITLE
refactor: make `boto3` an optional dependency under `s3` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ exclude = [
 dependencies = [
   "build==1.0.3",
   "coverage==7.3.3",
-  "moto==4.2.11",
+  "moto>=5.0.28",
   "mypy==1.7.1",
   "peewee>=3",
   "Pillow==10.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
   "Typing :: Typed",
 ]
-dependencies = [
-  "boto3~=1.25",
-]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -37,6 +34,9 @@ full = [
   "Pillow>=10",
   "sqlalchemy>=1.4",
   "peewee>=3",
+]
+s3 = [
+    "boto3>=1.37.38",
 ]
 
 [project.urls]

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from moto import mock_s3
+from moto import mock_aws as mock_s3
 
 from fastapi_storages import S3Storage, StorageFile
 


### PR DESCRIPTION
changes:
- [X] removed `boto3` from main dependencies to reduce base install footprint for non-S3 users
- [X] added `[project.optional-dependencies.s3]` section with updated `boto3` version
- [X] changed test import from `moto.mock_s3` (deprecated) to `moto.mock_aws`
- [ ] update readme and documentation